### PR TITLE
set correct file extension for Windows DLL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,19 @@
 OCAMLC=ocamlfind c
 OCAMLOPT=ocamlfind opt
 
+# determine shared library extension for target system
+ifeq ($(strip $(OS)),Windows_NT)
+	shared_ext=dll
+else
+	shared_ext=so
+endif
+
 all: stb_image.cma stb_image.cmxa
 
 ml_stb_image.o: ml_stb_image.c
 	$(OCAMLC) -c -ccopt "-O3 -std=gnu99 -ffast-math" $<
 
-dll_stb_image_stubs.so lib_stb_image_stubs.a: ml_stb_image.o
+dll_stb_image_stubs.$(shared_ext) lib_stb_image_stubs.a: ml_stb_image.o
 	ocamlmklib \
 	    -o _stb_image_stubs $< \
 	    -ccopt -O3 -ccopt -std=gnu99 -ccopt -ffast-math
@@ -17,23 +24,23 @@ stb_image.cmi: stb_image.mli
 stb_image.cmo: stb_image.ml stb_image.cmi
 	$(OCAMLC) -package result -c $<
 
-stb_image.cma: stb_image.cmo dll_stb_image_stubs.so
+stb_image.cma: stb_image.cmo dll_stb_image_stubs.$(shared_ext)
 	$(OCAMLC) -package result -a -custom -o $@ $< \
-	       -dllib dll_stb_image_stubs.so \
+	       -dllib dll_stb_image_stubs.$(shared_ext) \
 	       -cclib -l_stb_image_stubs
 
 stb_image.cmx: stb_image.ml stb_image.cmi
 	$(OCAMLOPT) -package result -c $<
 
-stb_image.cmxa stb_image.a: stb_image.cmx dll_stb_image_stubs.so
+stb_image.cmxa stb_image.a: stb_image.cmx dll_stb_image_stubs.$(shared_ext)
 	$(OCAMLOPT) -package result -a -o $@ $< \
-	      -cclib -l_stb_image_stubs \
-	  		-ccopt -O3 -ccopt -std=gnu99 -ccopt -ffast-math
+		-cclib -l_stb_image_stubs \
+		-ccopt -O3 -ccopt -std=gnu99 -ccopt -ffast-math
 
 .PHONY: clean install uninstall reinstall
 
 clean:
-	rm -f *.[oa] *.so *.cm[ixoa] *.cmxa
+	rm -f *.[oa] *.$(shared_ext) *.cm[ixoa] *.cmxa
 
 DIST_FILES=              \
 	stb_image.a            \
@@ -45,7 +52,7 @@ DIST_FILES=              \
 	stb_image.ml           \
 	stb_image.mli          \
 	lib_stb_image_stubs.a  \
-	dll_stb_image_stubs.so
+	dll_stb_image_stubs.$(shared_ext)
 
 install: $(DIST_FILES) META
 	ocamlfind install stb_image $^

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ stb_image.cmx: stb_image.ml stb_image.cmi
 
 stb_image.cmxa stb_image$(EXT_LIB): stb_image.cmx dll_stb_image_stubs$(EXT_DLL)
 	$(OCAMLOPT) -package result -a -o $@ $< \
-	      -cclib -l_stb_image_stubs \
-	      -ccopt -O3 -ccopt -std=gnu99 -ccopt -ffast-math
+	      -cclib -l_stb_image_stubs
 
 .PHONY: clean install uninstall reinstall
 


### PR DESCRIPTION
When build on Windows the Cygwin and MinGW toolchain automatically generates dynamic libs with .dll file extension. Therefore the Makefile should be adjusted for the target files to match. (Disclaimer: This commit has only been tested with OCaml 4.03 and MinGW x86_64 tools).

I'm not sure whether MacOSX would need a similar tweak.