### PR TITLE
Fix caml_alloc.

### DIFF
--- a/ml_stb_image.c
+++ b/ml_stb_image.c
@@ -24,7 +24,7 @@ static value return_image(void *data, int ty, int x, int y, int n)
 
   ba = caml_ba_alloc_dims(ty | CAML_BA_C_LAYOUT, 1, data, x * y * n);
 
-  tup = caml_alloc(4, 0);
+  tup = caml_alloc(6, 0);
   Store_field(tup, 0, Val_long(x));
   Store_field(tup, 1, Val_long(y));
   Store_field(tup, 2, Val_long(n));


### PR DESCRIPTION
Hi Fred,
I ran into some segfaults when switching to 4.08 and I think this was caused by this: maybe we should allocate 6 words rather than 4 to accommodate for all the fields ?